### PR TITLE
Update Conveyor configuration for 1.1

### DIFF
--- a/conveyor.conf
+++ b/conveyor.conf
@@ -4,21 +4,21 @@
 // mvn install -pl base
 // mvn prepare-package jar:jar -pl sampler
 
-// Use a vanilla Java 17 build, latest as of packaging.
-include required("/stdlib/jdk/17/openjdk.conf")
+// Use Amazon's Java 17 build, latest as of packaging. OpenJDK already moved on to 18.
+include required("/stdlib/jdk/17/amazon.conf")
 // Import JavaFX JMODs.
 include required("/stdlib/jvm/javafx/from-jmods.conf")
 // Small tweaks e.g. enabling proxy detection (https://conveyor.hydraulic.dev/2/stdlib/jvm-clients/)
 include required("/stdlib/jvm/enhancements/client/v1.conf")
 
-javafx.version = 18.0.2
+javafx.version = 17.0.1
 
 app {
   display-name = AtlantaFX Sampler
   fsname = atlantafx-sampler
 
   // Not allowed to have versions ending in -SNAPSHOT
-  version = 0.1
+  version = 1.1.0
 
   // Open source projects use Conveyor for free.
   vcs-url = github.com/mkpaz/atlantafx
@@ -35,7 +35,12 @@ app {
     modules = [ java.logging, jdk.localedata, java.desktop, java.prefs, javafx.controls, javafx.swing, javafx.web ]
   }
 
+  // Check for updates on every start and pop up a dialog if found, as this app will only be run occasionally (e.g. on new releases).
+  // NB: Update checks won't occur if the most recent update was done within <= 1 hour. This is Mac specific because on Windows update
+  // checks are done whether or not the app is running, and on Linux updates are handled by the package manager.
+  mac.updates = aggressive
+
   site.base-url = downloads.hydraulic.dev/atlantafx/sampler
 }
 
-conveyor.compatibility-level = 2
+conveyor.compatibility-level = 4


### PR DESCRIPTION
* New version
* Switch to Amazon JDK because they are still updating their Java 17 version.
* Align the JavaFX version: please note that JFX 17.0.1 has a critical bug that can cause crash on exit on macOS, so we should upgrade the sampler to the latest JFX at some point.
* Enable "aggressive updates" for macOS where an update check is done visibly on every launch. This will unfortunately only take effect once users have updated, not immediately, because it's a property of a released app, not something that's affected remotely. The default behavior is to update silently in the background whilst the app is running. That's appropriate for apps where the user is working with them, but for apps like this that are only run occasionally, it's better to be more assertive about updates up front.

