### PR TITLE
added file generation for SceneBuilder integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,23 @@ Application.setUserAgentStylesheet(new PrimerDark().getUserAgentStylesheet());
 
 Check the [docs](https://mkpaz.github.io/atlantafx/) for more information.
 
+## SceneBuilder Integration
+
+While SceneBuilder does not support adding custom themes, it is possible to overwrite looked up css paths to make the existing buttons load custom css files. In order to use AtlantaFX in SceneBuilder you need to
+
+1. run `mvn package -pl styles` to generate theme css files with the correct path names
+2. copy `styles/target/AtlantaFX-${version}-scenebuilder.zip` to the SceneBuilder `$APPDIR` (e.g. `%HOMEPATH%/Local/SceneBuilder/app/` on Windows) or another directory of your choice
+3. open `SceneBuilder.cfg` in the SceneBuilder app directory and add the zip file to the beginning of the `app.classpath` variable (e.g.  `app.classpath=$APPDIR\AtlantaFX-${version}-scenebuilder.zip;$APPDIR\scenebuilder-18.0.0-all.jar` on Windows)
+
+After restarting SceneBuilder you can now select AtlantaFX themes in the menu `Preview -> Themes -> Caspian Embedded (FX2)`. The themes are mapped as follows
+
+| SceneBuilder                | Modifier                    | AtlantaFX Theme |
+|-----------------------------|-----------------------------|-----------------|
+| Caspian Embedded (FX2)      | None                        | Primer Light    |
+| Caspian Embedded (FX2)      | Caspian High Contrast (FX2) | Primer Dark     |
+| Caspian Embedded QVGA (FX2) | None                        | Nord Light      |
+| Caspian Embedded QVGA (FX2) | Caspian High Contrast (FX2) | Nord Dark       |
+
 ## Contributing
 
 Contributions are always welcome! Contributing can mean many things such as participating in discussion or proposing changes. Feel free to open an issue if you've found a bug or want to raise a question, or discuss a possible feature.

--- a/styles/pom.xml
+++ b/styles/pom.xml
@@ -53,21 +53,36 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <outputDirectory>${project.build.directory}</outputDirectory>
+                    <attach>false</attach>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <tarLongFileMode>posix</tarLongFileMode>
+                </configuration>
                 <executions>
                     <execution>
-                        <id>assembly</id>
-                        <phase>install</phase>
+                        <id>assemble-themes</id>
+                        <phase>package</phase>
                         <goals>
                             <goal>single</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${project.build.directory}</outputDirectory>
                             <finalName>${app.name}-${app.version}-themes</finalName>
-                            <attach>false</attach>
-                            <appendAssemblyId>false</appendAssemblyId>
-                            <tarLongFileMode>posix</tarLongFileMode>
                             <descriptors>
                                 <descriptor>assembly.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>assemble-scenebuilder</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>${app.name}-${app.version}-scenebuilder</finalName>
+                            <descriptors>
+                                <descriptor>scenebuilder.xml</descriptor>
                             </descriptors>
                         </configuration>
                     </execution>

--- a/styles/scenebuilder.xml
+++ b/styles/scenebuilder.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+
+    <id>assembly</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+
+    <!-- original filenames -->
+    <fileSets>
+        <fileSet>
+            <outputDirectory>/com/oracle/javafx/scenebuilder/kit/util/css/caspian</outputDirectory>
+            <directory>dist/</directory>
+            <filtered>false</filtered>
+        </fileSet>
+    </fileSets>
+
+    <!-- rename to overwrite useragent stylesheets that are looked up by SceneBuilder -->
+    <files>
+        <file>
+            <outputDirectory>/com/oracle/javafx/scenebuilder/kit/util/css/caspian</outputDirectory>
+            <source>dist/primer-light.css</source>
+            <destName>caspian-embedded.css</destName>
+        </file>
+        <file>
+            <outputDirectory>/com/oracle/javafx/scenebuilder/kit/util/css/caspian</outputDirectory>
+            <source>dist/primer-dark.css</source>
+            <destName>caspian-embedded-highContrast.css</destName>
+        </file>
+        <file>
+            <outputDirectory>/com/oracle/javafx/scenebuilder/kit/util/css/caspian</outputDirectory>
+            <source>dist/nord-light.css</source>
+            <destName>caspian-embedded-qvga.css</destName>
+        </file>
+        <file>
+            <outputDirectory>/com/oracle/javafx/scenebuilder/kit/util/css/caspian</outputDirectory>
+            <source>dist/nord-dark.css</source>
+            <destName>caspian-embedded-qvga-highContrast.css</destName>
+        </file>
+    </files>
+
+</assembly>


### PR DESCRIPTION
see #27 

`mvn package -pl styles` generates an additional `AtlantaFX-1.1.0-scenebuilder.zip` file that maps the AtlantaFX themes to SceneBuilder buttons. I wasn't sure how to change the docs, so I just packed instructions into the Readme.

What do you think about adding a button in the sampler app that installs Themes into SceneBuilder w/o requiring manual steps? It'd be nice to make the integration as simple as possible.