### PR TITLE
Fixed Windows classpath and added default directory (fixes #42)

### DIFF
--- a/sampler/src/main/java/atlantafx/sampler/page/general/SceneBuilderDialog.java
+++ b/sampler/src/main/java/atlantafx/sampler/page/general/SceneBuilderDialog.java
@@ -181,6 +181,7 @@ class SceneBuilderDialog extends ModalDialog {
         browseBtn.setMinWidth(120);
         browseBtn.setOnAction(e -> {
             var dirChooser = new DirectoryChooser();
+            dirChooser.setInitialDirectory(SceneBuilderInstaller.getDefaultConfigDir().toFile());
             File dir = dirChooser.showDialog(getScene().getWindow());
             if (dir != null) {
                 model.setInstallDir(dir.toPath());

--- a/sampler/src/main/java/atlantafx/sampler/page/general/SceneBuilderInstaller.java
+++ b/sampler/src/main/java/atlantafx/sampler/page/general/SceneBuilderInstaller.java
@@ -28,6 +28,7 @@ final class SceneBuilderInstaller {
 
     private static final String CONFIG_FILE_NAME = "SceneBuilder.cfg";
     private static final String THEME_PACK_FILE_NAME = "atlantafx-scene-builder.zip";
+    private static final char CLASSPATH_SEPARATOR = PlatformUtils.isWindows() ? ';' : ':';
 
     private final Path sceneBuilderDir;
     private Path configDir;
@@ -169,7 +170,7 @@ final class SceneBuilderInstaller {
                 while (it.hasNext()) {
                     var line = it.next();
                     if (line != null && line.startsWith("app.classpath")) {
-                        it.set(line.replace("$APPDIR" + File.separator + THEME_PACK_FILE_NAME + ":", ""));
+                        it.set(line.replace("$APPDIR" + File.separator + THEME_PACK_FILE_NAME + CLASSPATH_SEPARATOR, ""));
                     }
                 }
 
@@ -218,6 +219,18 @@ final class SceneBuilderInstaller {
             }
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    public static Path getDefaultConfigDir() {
+        if (PlatformUtils.isWindows()) {
+            return Path.of(System.getProperty("user.home"), "AppData", "Local", "SceneBuilder");
+        } else if (PlatformUtils.isLinux()) {
+            return Path.of("/opt/scenebuilder/");
+        } else if (PlatformUtils.isUnix()) {
+            return Path.of("/Applications/SceneBuilder.app/");
+        } else {
+            return Path.of(".");
         }
     }
 


### PR DESCRIPTION
* fixed the SceneBuilder windows integration: the classpath expects `;` rather than `:`
* added an OS-appropriate initial directory

I tested the changes only on Windows. The Linux/macOS delimiter hasn't changed.