### PR TITLE
:bug: fix(SceneBuilderDialog): fix SceneBuilder Integration button port error

### DIFF
--- a/sampler/src/main/java/atlantafx/sampler/page/general/SceneBuilderDialog.java
+++ b/sampler/src/main/java/atlantafx/sampler/page/general/SceneBuilderDialog.java
@@ -181,7 +181,9 @@ class SceneBuilderDialog extends ModalDialog {
         browseBtn.setMinWidth(120);
         browseBtn.setOnAction(e -> {
             var dirChooser = new DirectoryChooser();
-            dirChooser.setInitialDirectory(SceneBuilderInstaller.getDefaultConfigDir().toFile());
+            File file = SceneBuilderInstaller.getDefaultConfigDir().toFile();
+            file = file.exists() ? file : new File(".");
+            dirChooser.setInitialDirectory(file);
             File dir = dirChooser.showDialog(getScene().getWindow());
             if (dir != null) {
                 model.setInstallDir(dir.toPath());


### PR DESCRIPTION
fix SceneBuilder Integration button report error( Folder parameter must be a valid folder) when SceneBuilder is not installed in the default directory