### PR TITLE
Show graphic in toggle switch

### DIFF
--- a/base/src/main/java/atlantafx/base/controls/ToggleSwitchSkin.java
+++ b/base/src/main/java/atlantafx/base/controls/ToggleSwitchSkin.java
@@ -79,11 +79,14 @@ public class ToggleSwitchSkin extends SkinBase<ToggleSwitch> {
         transition.setFromX(0.0);
 
         label.textProperty().bind(control.textProperty());
+        label.graphicProperty().bind(control.graphicProperty());
+        label.alignmentProperty().bind(control.alignmentProperty());
         StackPane.setAlignment(label, Pos.CENTER_LEFT);
 
         labelContainer.getChildren().addAll(label);
         getChildren().addAll(labelContainer, thumbArea, thumb);
 
+        label.setOnMouseReleased(event -> mousePressedOnToggleSwitch(control));
         thumbArea.setOnMouseReleased(event -> mousePressedOnToggleSwitch(control));
         thumb.setOnMouseReleased(event -> mousePressedOnToggleSwitch(control));
         control.selectedProperty().addListener((observable, oldValue, newValue) -> {
@@ -161,7 +164,7 @@ public class ToggleSwitchSkin extends SkinBase<ToggleSwitch> {
         double thumbAreaHeight = snapSizeX(thumbArea.prefHeight(-1));
         double thumbAreaY = snapPositionX(contentY + (contentHeight / 2) - (thumbAreaHeight / 2));
 
-        double labelWidth = label.getText() != null && !label.getText().isEmpty() ? contentWidth - thumbAreaWidth : 0;
+        double labelWidth = (label.getText() != null && !label.getText().isEmpty()) || label.getGraphic() != null ? contentWidth - thumbAreaWidth : 0;
         double labelX = c.getLabelPosition() == HorizontalDirection.RIGHT ? thumbAreaWidth : 0;
 
         double thumbAreaX = c.getLabelPosition() == HorizontalDirection.RIGHT ? 0 : labelWidth;


### PR DESCRIPTION
Right now, the toggle switch ignores the graphic, this PR fixes this.

I also get the following error when building the sampler, not sure why:

    [ERROR] Failed to execute goal on project atlantafx-sampler: Could not resolve dependencies for project io.github.mkpaz:atlantafx-sampler:jar:2.0.1: Failed to collect dependencies at io.github.mkpaz:devtoolsfx-gui:jar:1.0.0: Failed to read artifact descriptor for io.github.mkpaz:devtoolsfx-gui:jar:1.0.0: io.github.mkpaz:devtoolsfx:pom:1.0.0 was not found in https://repo.maven.apache.org/maven2 during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of central has elapsed or updates are forced -> [Help 1]
    [ERROR] 
    [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
    [ERROR] Re-run Maven using the -X switch to enable full debug logging.
    [ERROR] 
    [ERROR] For more information about the errors and possible solutions, please read the following articles:
    [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException