### PR TITLE
Fix modal pane transitions on content change

### DIFF
--- a/base/src/main/java/atlantafx/base/controls/ModalPaneSkin.java
+++ b/base/src/main/java/atlantafx/base/controls/ModalPaneSkin.java
@@ -69,6 +69,17 @@ public class ModalPaneSkin extends SkinBase<ModalPane> {
     protected void registerListeners() {
         registerChangeListener(getSkinnable().contentProperty(), obs -> {
             @Nullable Node content = getSkinnable().getContent();
+
+            // The transition is node-based
+            if (inTransition != null) {
+                inTransition.statusProperty().removeListener(animationInListener);
+            }
+            inTransition = null;
+            if (outTransition != null) {
+                outTransition.statusProperty().removeListener(animationOutListener);
+            }
+            outTransition = null;
+
             if (content != null) {
                 contentWrapper.getChildren().setAll(content);
             } else {


### PR DESCRIPTION
When changing the content of a modal pane, the transitions from the previous content node are not removed and the transitions don't play for the new content. This PR fixes that