### PR TITLE
feat(toggle-button): Add the ToggleButton size style class

### DIFF
--- a/sampler/src/main/java/atlantafx/sampler/page/components/ToggleButtonPage.java
+++ b/sampler/src/main/java/atlantafx/sampler/page/components/ToggleButtonPage.java
@@ -36,6 +36,7 @@ public final class ToggleButtonPage extends OutlinePage {
         addSection("Icon Only", iconOnlyExample());
         addSection("Segmented Group", segmentedGroupExample());
         addSection("Flat", flatExample());
+        addSection("ToggleButton Size", toggleButtonSizeExample());
     }
 
     private ExampleBox usageExample() {
@@ -232,5 +233,28 @@ public final class ToggleButtonPage extends OutlinePage {
         box.setAlignment(Pos.CENTER_LEFT);
 
         return new ExampleBox(box, new Snippet(getClass(), 4));
+    }
+
+    private ExampleBox toggleButtonSizeExample() {
+        //snippet_5:start
+        var smallBtn = new ToggleButton("Small");
+        smallBtn.getStyleClass().add(Styles.SMALL);
+        smallBtn.setSelected(true);
+
+        var normalBtn = new ToggleButton("Normal");
+
+        var largeBtn = new ToggleButton("Large");
+        largeBtn.getStyleClass().add(Styles.LARGE);
+        //snippet_5:end
+
+        var box = new HBox(HGAP_20, smallBtn, normalBtn, largeBtn);
+        box.setAlignment(Pos.CENTER_LEFT);
+
+        var description = BBCodeParser.createFormattedText("""
+            For larger or smaller buttons, use the [code]Styles.SMALL[/code] or \
+            [code]Styles.LARGE[/code] style classes, respectively."""
+        );
+
+        return new ExampleBox(box, new Snippet(getClass(), 5), description);
     }
 }

--- a/styles/src/components/_toggle-button.scss
+++ b/styles/src/components/_toggle-button.scss
@@ -66,4 +66,14 @@ $color-border-selected: -color-accent-emphasis  !default;
   &:selected.right-pill:focused {
     -fx-background-insets: 0, cfg.$border-width;
   }
+
+  &.small {
+    -fx-padding: cfg.$padding-y-small cfg.$padding-x-small cfg.$padding-y-small cfg.$padding-x-small;
+    -fx-font-size: cfg.$font-small;
+  }
+
+  &.large {
+    -fx-padding: cfg.$padding-y-large cfg.$padding-x-large cfg.$padding-y-large cfg.$padding-x-large;
+    -fx-font-size: cfg.$font-title-4;
+  }
 }


### PR DESCRIPTION
In the _toggle-button.scss file, small and large size style classes have been added, allowing the button size to be controlled through the style classes. At the same time, examples have been added to the ToggleButtonPage to demonstrate how to use these new style classes.

- The '.small 'and'.large 'style classes have been added in' _toggle-button.scss '
- In the ToggleButtonPage, the toggleButtonSizeExample method was added to demonstrate the usage of button sizes
- The page content has been updated, with explanations and examples about button sizes added